### PR TITLE
Fixed blank rest actions issue

### DIFF
--- a/mc/gui/rest_actions_cw.py
+++ b/mc/gui/rest_actions_cw.py
@@ -114,6 +114,8 @@ class RestActionsComposite(QtWidgets.QWidget):
                 return
 
     def add_rest_action_clicked(self):
+        if not(self.rest_add_action_qle.text().strip()):
+            return
         model.RestActionsM.add(
             self.rest_add_action_qle.text().strip(),
             ""


### PR DESCRIPTION
Modified rest_actions_cw.py such that when user attempts to add, if nothing is entered, will return scope rather than adding the blank entry.