### PR TITLE
Fix typo.

### DIFF
--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -35,8 +35,8 @@ TBD: Verify that only one rest dialog appears if multiple are "passed"
 4. wait one minute for the dialog to be shown again
 5. verify: the dialog is shown
 6. change the wait time value to 5
-7. verify: in the main interface the remining time is shown as 5
-8. verify: in the system tray menu the remining time is shown as the percentage you would expect (ex: if rest interval is 20 minutes we expect 75% of the systray progress bar to be filled)
+7. verify: in the main interface the remaining time is shown as 5
+8. verify: in the system tray menu the remaining time is shown as the percentage you would expect (ex: if rest interval is 20 minutes we expect 75% of the systray progress bar to be filled)
 
 
 


### PR DESCRIPTION
Fix typo in docs/manual-testing.md: remining -> remaining.