### PR TITLE
First phrase selected as default when the edit dialog is called

### DIFF
--- a/mc/gui/breathing_phrase_list_dock.py
+++ b/mc/gui/breathing_phrase_list_dock.py
@@ -211,8 +211,7 @@ class EditDialog(QtWidgets.QDialog):
         super(EditDialog, self).__init__(i_parent)
 
         if mc.mc_global.active_phrase_id_it == mc.mc_global.NO_PHRASE_SELECTED_INT:
-            mc.mc_global.active_phrase_id_it = 1
-            
+            mc.mc_global.active_phrase_id_it = 1   
         active_phrase = mc.model.PhrasesM.get(mc.mc_global.active_phrase_id_it)
 
         vbox = QtWidgets.QVBoxLayout(self)

--- a/mc/gui/breathing_phrase_list_dock.py
+++ b/mc/gui/breathing_phrase_list_dock.py
@@ -210,7 +210,9 @@ class EditDialog(QtWidgets.QDialog):
     def __init__(self, i_parent=None):
         super(EditDialog, self).__init__(i_parent)
 
-        assert mc.mc_global.active_phrase_id_it != mc.mc_global.NO_PHRASE_SELECTED_INT
+        if mc.mc_global.active_phrase_id_it == mc.mc_global.NO_PHRASE_SELECTED_INT:
+            mc.mc_global.active_phrase_id_it = 1
+            
         active_phrase = mc.model.PhrasesM.get(mc.mc_global.active_phrase_id_it)
 
         vbox = QtWidgets.QVBoxLayout(self)


### PR DESCRIPTION
In line 213 the assertion fails when edit dialog is called with no phrase selected. 
Solution: select the first phrase as default if the user doesn't select a phrase.